### PR TITLE
- Changed reference to AutoMapper to the range `[11.0, 12.0)`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - name: Use .NET 6
+      uses: actions/setup-dotnet@v1
     - name: Build and Test
       run: ./Build.ps1
       shell: pwsh

--- a/src/AutoMapper.Extensions.EnumMapping.Tests/AutoMapper.Extensions.EnumMapping.Tests.csproj
+++ b/src/AutoMapper.Extensions.EnumMapping.Tests/AutoMapper.Extensions.EnumMapping.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
@@ -22,19 +22,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\AutoMapper.Extensions.EnumMapping\AutoMapper.Extensions.EnumMapping.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AutoMapper.Extensions.EnumMapping/AutoMapper.Extensions.EnumMapping.csproj
+++ b/src/AutoMapper.Extensions.EnumMapping/AutoMapper.Extensions.EnumMapping.csproj
@@ -5,7 +5,7 @@
     <Company>Henk Kin</Company>
     <Summary>Convention-based enum value mapping extension for AutoMapper.</Summary>
     <Description>Convention-based enum value mapping extension for AutoMapper.</Description>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>AutoMapper.Extensions.EnumMapping</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\AutoMapper.snk</AssemblyOriginatorKeyFile>
@@ -24,17 +24,10 @@
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="[11.0, 12.0)" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="[10.0, 11.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AutoMapper.Extensions.EnumMapping/EnumMapperConfigurationExpressionExtensions.cs
+++ b/src/AutoMapper.Extensions.EnumMapping/EnumMapperConfigurationExpressionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using AutoMapper.Extensions.EnumMapping.Internal;
+using AutoMapper.Internal;
 
 namespace AutoMapper.Extensions.EnumMapping
 {
@@ -14,7 +15,7 @@ namespace AutoMapper.Extensions.EnumMapping
         /// <param name="mapperConfigurationExpression">Configuration object for AutoMapper</param>
         public static void EnableEnumMappingValidation(this IMapperConfigurationExpression mapperConfigurationExpression)
         {
-            mapperConfigurationExpression.Advanced.Validator(context =>
+            mapperConfigurationExpression.Internal().Validator(context =>
             {
                 if (context.TypeMap != null)
                 {

--- a/src/AutoMapper.Extensions.EnumMapping/Internal/EnumMappingValidationRuntimeFeature.cs
+++ b/src/AutoMapper.Extensions.EnumMapping/Internal/EnumMappingValidationRuntimeFeature.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using AutoMapper.Internal;
 
 namespace AutoMapper.Extensions.EnumMapping.Internal
 {
@@ -17,7 +18,7 @@ namespace AutoMapper.Extensions.EnumMapping.Internal
             _enumMappingType = enumMappingType;
         }
 
-        public void Seal(IConfigurationProvider configurationProvider)
+        public void Seal(IGlobalConfiguration configurationProvider)
         {
         }
 

--- a/src/AutoMapper.Extensions.EnumMapping/Internal/IEnumMappingValidationRuntimeFeature.cs
+++ b/src/AutoMapper.Extensions.EnumMapping/Internal/IEnumMappingValidationRuntimeFeature.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper.Features;
+using AutoMapper.Internal;
 
 namespace AutoMapper.Extensions.EnumMapping.Internal
 {


### PR DESCRIPTION
As a breaking change from version `11` onwards is dropped support for `net461` it seems unreasonable to keep support for this framework in the extension also.

- Switched targets to only support `netstandard2.1`

This is due to the fact that AutoMapper from version `11` has dropped support for `net461` target.

Also removed optional dependencies, as package only target single framework now.

- Switched targets for test project to `net6.0`

Mainly because AutoMapper `11` targets `netstandard2.1` and this is not supported in `netcoreapp2.1`, also this target framework is no longer supported generally so updating seems like a good idea.

Secondly I work on an Apple Silicon machine, so bumping to something compatible with .Net 6 was required for me to be able to run the tests.

- Updated using statements to target `AutoMapper.Internal` when necessary
- Use new `.Internal()` rather than old `.Advanced`